### PR TITLE
Update DallasTemperature.cpp

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -452,6 +452,7 @@ float DallasTemperature::calculateTemperature(uint8_t *deviceAddress,
             (float)scratchPad[COUNT_PER_C]);
     break;
   }
+    return NAN;
 }
 
 // returns temperature in degrees C or DEVICE_DISCONNECTED if the


### PR DESCRIPTION
Due to compiler error
lib\MAX31850 DallasTemp\DallasTemperature.cpp:495:1: error: control reaches end of non-void function [-Werror=return-type]
